### PR TITLE
Handles { arrayProp:null } correctly when expecting { arrayProp:[] }

### DIFF
--- a/src/main/java/org/openx/data/jsonserde/objectinspector/JsonListObjectInspector.java
+++ b/src/main/java/org/openx/data/jsonserde/objectinspector/JsonListObjectInspector.java
@@ -17,6 +17,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
 import org.openx.data.jsonserde.json.JSONArray;
 import org.openx.data.jsonserde.json.JSONException;
+import org.openx.data.jsonserde.json.JSONObject;
 
 /**
  *
@@ -30,7 +31,7 @@ public class JsonListObjectInspector extends StandardListObjectInspector {
 
      @Override
   public List<?> getList(Object data) {
-    if (data == null) {
+    if (data == null || JSONObject.NULL.equals(data)) {
       return null;
     }
     JSONArray array = (JSONArray) data;


### PR DESCRIPTION
I didn't check to see if the same thing is happening for Maps but { arrayProp:null } should be considered valid JSON.

Previously this would throw:

org.apache.hadoop.hive.ql.metadata.HiveException: Hive Runtime Error while processing row [Error getting row data with exception java.lang.ClassCastException: org.openx.data.jsonserde.json.JSONObject$Null cannot be cast to org.openx.data.jsonserde.json.JSONArray
    at org.openx.data.jsonserde.objectinspector.JsonListObjectInspector.getList(JsonListObjectInspector.java:36)
