### PR TITLE
Equals check always false.

### DIFF
--- a/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -95,7 +95,7 @@ public class JSONObject {
      * whilst Java's null is equivalent to the value that JavaScript calls
      * undefined.
      */
-     private static final class Null {
+     private static final class Null extends JSONObject {
 
         /**
          * There is only intended to be a single instance of the NULL object,


### PR DESCRIPTION
- The equals is checking if object is not instance of JSONObject and it
  is always the case. Changed the Null to be instance of JSONObject
