### PR TITLE
Custom primitive object inspectors in the Serde need to override getPrimitiveJavaObject also

### DIFF
--- a/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringByteObjectInspector.java
+++ b/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringByteObjectInspector.java
@@ -40,6 +40,11 @@ public class JavaStringByteObjectInspector   extends AbstractPrimitiveJavaObject
     }
 
     @Override
+    public Object getPrimitiveJavaObject(Object o) {
+        return o == null ? null : get(o);
+    }
+
+    @Override
     public byte get(Object o) {
         if(o instanceof String) {
            return ParsePrimitiveUtils.parseByte((String)o); 

--- a/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDoubleObjectInspector.java
+++ b/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDoubleObjectInspector.java
@@ -40,6 +40,11 @@ public class JavaStringDoubleObjectInspector extends AbstractPrimitiveJavaObject
     }
 
     @Override
+    public Object getPrimitiveJavaObject(Object o) {
+        return o == null ? null : get(o);
+    }
+
+    @Override
     public double get(Object o) {
         
         if(o instanceof String) {

--- a/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringFloatObjectInspector.java
+++ b/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringFloatObjectInspector.java
@@ -40,6 +40,11 @@ public class JavaStringFloatObjectInspector extends AbstractPrimitiveJavaObjectI
     }
 
     @Override
+    public Object getPrimitiveJavaObject(Object o) {
+        return o == null ? null : get(o);
+    }
+
+    @Override
     public float get(Object o) {
         
         if(o instanceof String) {

--- a/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringIntObjectInspector.java
+++ b/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringIntObjectInspector.java
@@ -41,6 +41,11 @@ public class JavaStringIntObjectInspector
     }
 
     @Override
+    public Object getPrimitiveJavaObject(Object o) {
+        return o == null ? null : get(o);
+    }
+
+    @Override
     public int get(Object o) {
         if(o instanceof String) {
            return ParsePrimitiveUtils.parseInt((String)o); 

--- a/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringLongObjectInspector.java
+++ b/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringLongObjectInspector.java
@@ -41,6 +41,11 @@ public class JavaStringLongObjectInspector
     }
 
     @Override
+    public Object getPrimitiveJavaObject(Object o) {
+        return o == null ? null : get(o);
+    }
+
+    @Override
     public long get(Object o) {
         
         if(o instanceof String) {

--- a/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringShortObjectInspector.java
+++ b/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringShortObjectInspector.java
@@ -41,6 +41,11 @@ public class JavaStringShortObjectInspector
     }
 
     @Override
+    public Object getPrimitiveJavaObject(Object o) {
+        return o == null ? null : get(o);
+    }
+
+    @Override
     public short get(Object o) {
         
         if(o instanceof String) {


### PR DESCRIPTION
This fixes https://github.com/rcongiu/Hive-JSON-Serde/issues/67

From `org.apache.hadoop.hive.ql.udf.generic.GenericUDAFMax.GenericUDAFMaxEvaluator#merge`

The aggregation buffer is being initialized here and the object inspector we have here is from the Serde. And in these primitiveObjectInspectors, getPrimitiveJavaObject hasn't been overridden.

``` java
        if (myagg.o == null || r < 0) {
          myagg.o = ObjectInspectorUtils.copyToStandardObject(partial, inputOI,
              ObjectInspectorCopyOption.JAVA);
        }
```
