### PR TITLE
Fix for \a or \v, because  Java does not recognize in strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+.idea/
+*.iml

--- a/src/main/java/org/openx/data/jsonserde/json/JSONTokener.java
+++ b/src/main/java/org/openx/data/jsonserde/json/JSONTokener.java
@@ -283,6 +283,11 @@ public class JSONTokener {
                 case 'u':
                     sb.append((char)Integer.parseInt(next(4), 16));
                     break;
+                case 'a':
+                    sb.append("\007");
+                case 'v':
+                    sb.append("\011");
+                    break;
                 case '"':
                 case '\'':
                 case '\\':

--- a/src/test/java/org/openx/data/jsonserde/ProtobufJsonTest.java
+++ b/src/test/java/org/openx/data/jsonserde/ProtobufJsonTest.java
@@ -1,0 +1,44 @@
+package org.openx.data.jsonserde;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.Constants;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.junit.Test;
+import org.openx.data.jsonserde.json.JSONObject;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: ps16819
+ * Date: 6/3/14
+ * Time: 1:14 PM
+ * To change this template use File | Settings | File Templates.
+ */
+public class ProtobufJsonTest {
+    public void initialize(JsonSerDe instance) throws Exception {
+        System.out.println("initialize");
+
+        Configuration conf = null;
+        Properties tbl = new Properties();
+        tbl.setProperty(Constants.LIST_COLUMNS, "one");
+        tbl.setProperty(Constants.LIST_COLUMN_TYPES, "string");
+
+        instance.initialize(conf, tbl);
+    }
+
+    @Test
+    public void deserializeStrangeString() throws Exception {
+        JsonSerDe instance = new JsonSerDe();
+        initialize(instance);
+
+        System.out.println("deserialize");
+        Writable w = new Text("{\"one\":\"\\a\\v\"}");
+
+        JSONObject result = (JSONObject) instance.deserialize(w);
+        assertEquals("",result.get("one").toString().trim());
+    }
+}


### PR DESCRIPTION
There is a problem with Bell Char (0x07) and Line tabulation char (0x0b) which Java does not recognize.
They are encoded as \a and \v for example in com.google.protobuf (http://code.google.com/p/protobuf-java-format/source/browse/branches/r47-antbuild/src/java/com/google/protobuf/JsonFormat.java) during serialization to JSON.

I added fix for above problem with test included.
