### PR TITLE
parsing primitive values in a try/catch block

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
@@ -169,7 +169,7 @@ public class JsonSerDe implements SerDe {
             } else if (txt.startsWith("[")){
                 jObj = new JSONArray(txt);
             }
-        } catch (JSONException e) {
+        } catch (Exception e) {
             // If row is not a JSON object, make the whole row NULL
             onMalformedJson("Row is not a valid JSON Object - JSONException: "
                     + e.getMessage());

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDoubleObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDoubleObjectInspector.java
@@ -14,7 +14,7 @@ package org.openx.data.jsonserde.objectinspector.primitive;
 
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.SettableDoubleObjectInspector;
-import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 
 /**
  *
@@ -31,20 +31,28 @@ public class JavaStringDoubleObjectInspector extends AbstractPrimitiveJavaObject
     public Object getPrimitiveWritableObject(Object o) {
         if(o == null) return null;
         
-        if(o instanceof String) {
-           return new DoubleWritable(Double.parseDouble((String)o)); 
-        } else {
-          return new DoubleWritable(((Double) o));
+        try {
+            if(o instanceof String) {
+                return new DoubleWritable(Double.parseDouble((String)o));
+            } else {
+                return new DoubleWritable(((Double) o));
+            }
+        }catch (Exception e){
+            return new DoubleWritable(0.0);
         }
     }
 
     @Override
     public double get(Object o) {
         
-        if(o instanceof String) {
-           return Double.parseDouble((String)o); 
-        } else {
-          return (((Double) o));
+        try {
+            if(o instanceof String) {
+                return Double.parseDouble((String)o);
+            } else {
+                return (((Double) o));
+            }
+        }catch (Exception e){
+            return 0.0;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringFloatObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringFloatObjectInspector.java
@@ -40,10 +40,14 @@ public class JavaStringFloatObjectInspector extends AbstractPrimitiveJavaObjectI
 
     @Override
     public float get(Object o) {  
-        if(o instanceof String) {
-          return Float.parseFloat((String)o); 
-        } else {
-          return ((Float) o);
+        try {
+            if(o instanceof String) {
+                return Float.parseFloat((String)o);
+            } else {
+                return ((Float) o);
+            }
+        }catch (Exception e){
+            return 0.0f;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringIntObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringIntObjectInspector.java
@@ -41,10 +41,14 @@ public class JavaStringIntObjectInspector
 
     @Override
     public int get(Object o) {
-        if(o instanceof String) {
-           return ParsePrimitiveUtils.parseInt((String)o); 
-        } else {
-           return ((Integer) o);
+        try {
+            if(o instanceof String) {
+                return ParsePrimitiveUtils.parseInt((String)o);
+            } else {
+                return ((Integer) o);
+            }
+        }catch (Exception e){
+            return 0;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringLongObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringLongObjectInspector.java
@@ -42,10 +42,14 @@ public class JavaStringLongObjectInspector
     @Override
     public long get(Object o) {
 
-        if(o instanceof String) {
-           return ParsePrimitiveUtils.parseLong((String)o);
-        } else {
-          return ((Long) o);
+        try {
+            if(o instanceof String) {
+                return ParsePrimitiveUtils.parseLong((String)o);
+            } else {
+                return ((Long) o);
+            }
+        }catch (Exception e){
+            return 0;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringShortObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringShortObjectInspector.java
@@ -42,10 +42,14 @@ public class JavaStringShortObjectInspector
     @Override
     public short get(Object o) {
         
-        if(o instanceof String) {
-           return ParsePrimitiveUtils.parseShort((String)o); 
-        } else {
-          return ((Short) o);
+        try {
+            if(o instanceof String) {
+                return ParsePrimitiveUtils.parseShort((String)o);
+            } else {
+                return ((Short) o);
+            }
+        }catch (Exception e){
+            return 0;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JsonStringJavaObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JsonStringJavaObjectInspector.java
@@ -36,7 +36,7 @@ public class JsonStringJavaObjectInspector extends
 
   @Override
   public String getPrimitiveJavaObject(Object o) {
-    return (String) o.toString();
+    return o==null?null:(String) o.toString();
   }
 
   @Override

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
@@ -27,26 +27,38 @@ public class ParsePrimitiveUtils {
     }
 
     public static int parseInt(String s) {
-        if (isHex(s)) {
-            return Integer.parseInt(s.substring(2), 16);
-        } else {
-            return Integer.parseInt(s);
+        try {
+            if (isHex(s)) {
+                return Integer.parseInt(s.substring(2), 16);
+            } else {
+                return Integer.parseInt(s);
+            }
+        }catch (Exception e){
+            return 0;
         }
     }
 
     public static short parseShort(String s) {
-        if (isHex(s)) {
-            return Short.parseShort(s.substring(2), 16);
-        } else {
-            return Short.parseShort(s);
+        try {
+            if (isHex(s)) {
+                return Short.parseShort(s.substring(2), 16);
+            } else {
+                return Short.parseShort(s);
+            }
+        } catch (Exception e){
+            return 0;
         }
     }
 
     public static long parseLong(String s) {
-        if (isHex(s)) {
-            return Long.parseLong(s.substring(2), 16);
-        } else {
-            return Long.parseLong(s);
+        try {
+            if (isHex(s)) {
+                return Long.parseLong(s.substring(2), 16);
+            } else {
+                return Long.parseLong(s);
+            }
+        }catch (Exception e){
+            return 0;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <cdh4.hive.version>0.10.0-cdh${cdh4.version}</cdh4.hive.version>
         <cdh4.hadoop.version>2.0.0-cdh${cdh4.version}</cdh4.hadoop.version>
         <!-- cdh5 versions -->
-        <cdh5.version>5.0.0</cdh5.version>
-        <cdh5.hive.version>0.12.0-cdh${cdh5.version}</cdh5.hive.version>
-        <cdh5.hadoop.version>2.3.0-cdh${cdh5.version}</cdh5.hadoop.version>
+        <cdh5.version>5.3.0</cdh5.version>
+        <cdh5.hive.version>0.13.1-cdh${cdh5.version}</cdh5.hive.version>
+        <cdh5.hadoop.version>2.5.0-cdh${cdh5.version}</cdh5.hadoop.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
While Parsing the data columns for hive in a very large file, some wrong/corrupted values (resulting in NumberFormatException) should not break the MR job. 
so this change parse all the primitive values in ParsePrimitiveUtils.java inside a try/catch block. Please pull this change.
