### PR TITLE
Add support for String to Boolean conversion

### DIFF
--- a/json-serde-cdh5-shim/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/TypeEntryShim.java
+++ b/json-serde-cdh5-shim/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/TypeEntryShim.java
@@ -28,4 +28,5 @@ public class TypeEntryShim {
     public static PrimitiveTypeInfo shortType = TypeInfoFactory.shortTypeInfo;
     public static PrimitiveTypeInfo timestampType = TypeInfoFactory.timestampTypeInfo;
     public static PrimitiveTypeInfo stringType = TypeInfoFactory.stringTypeInfo;
+    public static PrimitiveTypeInfo booleanType = TypeInfoFactory.booleanTypeInfo;
 }

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonObjectInspectorFactory.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonObjectInspectorFactory.java
@@ -27,6 +27,7 @@ import org.openx.data.jsonserde.objectinspector.primitive.JavaStringIntObjectIns
 import org.openx.data.jsonserde.objectinspector.primitive.JavaStringLongObjectInspector;
 import org.openx.data.jsonserde.objectinspector.primitive.JavaStringShortObjectInspector;
 import org.openx.data.jsonserde.objectinspector.primitive.JavaStringTimestampObjectInspector;
+import org.openx.data.jsonserde.objectinspector.primitive.JavaStringBooleanObjectInspector;
 
 /**
  *
@@ -205,6 +206,7 @@ public class JsonObjectInspectorFactory {
         primitiveOICache.put(PrimitiveCategory.FLOAT, new JavaStringFloatObjectInspector());
         primitiveOICache.put(PrimitiveCategory.DOUBLE, new JavaStringDoubleObjectInspector());
         primitiveOICache.put(PrimitiveCategory.TIMESTAMP, new JavaStringTimestampObjectInspector());
+        primitiveOICache.put(PrimitiveCategory.BOOLEAN, new JavaStringBooleanObjectInspector());
     }
     
     /**

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringBooleanObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringBooleanObjectInspector.java
@@ -1,0 +1,67 @@
+/*======================================================================*
+ * Copyright (c) 2011, OpenX Technologies, Inc. All rights reserved.    *
+ *                                                                      *
+ * Licensed under the New BSD License (the "License"); you may not use  *
+ * this file except in compliance with the License. Unless required     *
+ * by applicable law or agreed to in writing, software distributed      *
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT        *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.     *
+ * See the License for the specific language governing permissions and  *
+ * limitations under the License. See accompanying LICENSE file.        *
+ *======================================================================*/
+
+package org.openx.data.jsonserde.objectinspector.primitive;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.SettableBooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.BooleanWritable;
+
+/**
+ *
+ * @author rajat.85@gmail.com
+ */
+public class JavaStringBooleanObjectInspector extends AbstractPrimitiveJavaObjectInspector
+  implements SettableBooleanObjectInspector {
+
+  public JavaStringBooleanObjectInspector() {
+    super(TypeEntryShim.booleanType);
+  }
+
+  @Override
+  public Object getPrimitiveWritableObject(Object o) {
+    if(o == null) return null;
+
+    if(o instanceof String) {
+      return new BooleanWritable(Boolean.parseBoolean((String) o));
+    } else {
+      return new BooleanWritable(((Boolean) o));
+    }
+  }
+
+  @Override
+  public boolean get(Object o) {
+
+    if(o instanceof String) {
+      return Boolean.parseBoolean((String) o);
+    } else {
+      return (((Boolean) o));
+    }
+  }
+
+  @Override
+  public Object getPrimitiveJavaObject(Object o) {
+    return get(o);
+  }
+
+  @Override
+  public Object create(boolean value) {
+    return value;
+  }
+
+  @Override
+  public Object set(Object o, boolean value) {
+    return value;
+  }
+
+}

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.openx.data.jsonserde.objectinspector.primitive.JavaStringBooleanObjectInspector;
 import org.openx.data.jsonserde.objectinspector.primitive.JavaStringByteObjectInspector;
 import org.openx.data.jsonserde.objectinspector.primitive.JavaStringDoubleObjectInspector;
 import org.openx.data.jsonserde.objectinspector.primitive.JavaStringFloatObjectInspector;
@@ -383,8 +384,8 @@ public class JsonSerDeTest {
 	
         StructField sf = soi.getStructFieldRef("cboolean");
 	
-	assertTrue(sf.getFieldObjectInspector() instanceof JavaBooleanObjectInspector);
-        JavaBooleanObjectInspector jboi = (JavaBooleanObjectInspector) sf.getFieldObjectInspector();
+	assertTrue(sf.getFieldObjectInspector() instanceof JavaStringBooleanObjectInspector);
+        JavaStringBooleanObjectInspector jboi = (JavaStringBooleanObjectInspector) sf.getFieldObjectInspector();
 	assertEquals(true, jboi.get(result.get("cboolean")));
 	
 	sf = soi.getStructFieldRef("ctinyint");
@@ -432,8 +433,8 @@ public class JsonSerDeTest {
 	
         StructField sf = soi.getStructFieldRef("cboolean");
 	
-	assertTrue(sf.getFieldObjectInspector() instanceof JavaBooleanObjectInspector);
-        JavaBooleanObjectInspector jboi = (JavaBooleanObjectInspector) sf.getFieldObjectInspector();
+	assertTrue(sf.getFieldObjectInspector() instanceof JavaStringBooleanObjectInspector);
+        JavaStringBooleanObjectInspector jboi = (JavaStringBooleanObjectInspector) sf.getFieldObjectInspector();
 	assertEquals(true, jboi.get(result.get("cboolean")));
 	
 	sf = soi.getStructFieldRef("ctinyint");


### PR DESCRIPTION
JSON rows of the form:

```
{ 'colname': 'true'}
```

are failing with ClassCastException (unable to cast from String to boolean) when `colname` is of type `boolean`. This pull request adds support for the same.