### PR TITLE
Add support for UTC date format

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
@@ -6,13 +6,18 @@
 package org.openx.data.jsonserde.objectinspector.primitive;
 
 import java.sql.Timestamp;
-import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 
 /**
  *
  * @author rcongiu
  */
 public class ParsePrimitiveUtils {
+
+    private static DateFormat UTC_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    private static DateFormat NON_UTC_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     public static boolean isHex(String s) {
         return s.startsWith("0x") || s.startsWith("0X");
@@ -53,7 +58,7 @@ public class ParsePrimitiveUtils {
     public static Timestamp parseTimestamp(String s) {
         Timestamp value;
         if (s.indexOf(':') > 0) {
-            value = Timestamp.valueOf(s);
+            value = Timestamp.valueOf(nonUTCFormat(s));
         } else if (s.indexOf('.') >= 0) {
             // it's a float
             value = new Timestamp(
@@ -63,6 +68,17 @@ public class ParsePrimitiveUtils {
             value = new Timestamp(Long.parseLong(s) * 1000);
         }
         return value;
+    }
+
+    public static String nonUTCFormat(String s) {
+        if(s.endsWith("Z")) {
+            try {
+                return NON_UTC_FORMAT.format(UTC_FORMAT.parse(s));
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        return s;
     }
 
 }

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTimeStampTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTimeStampTest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 
 import static org.junit.Assert.assertEquals;
 import org.openx.data.jsonserde.objectinspector.primitive.JavaStringTimestampObjectInspector;
+import org.openx.data.jsonserde.objectinspector.primitive.ParsePrimitiveUtils;
 
 /**
  * User: guyrt
@@ -64,6 +65,20 @@ public class JsonSerDeTimeStampTest {
     StructObjectInspector soi = (StructObjectInspector) instance.getObjectInspector();
     
     JavaStringTimestampObjectInspector jstOi = (JavaStringTimestampObjectInspector) 
+            soi.getStructFieldRef("five").getFieldObjectInspector();
+    assertEquals(Timestamp.valueOf("2013-03-27 23:18:40.0"), jstOi.getPrimitiveJavaObject(result.get("five")));
+  }
+
+  @Test
+  public void testUTCTimestampDeSerialize() throws Exception {
+    // Test that timestamp object can be deserialized
+    Writable w = new Text("{\"one\":true,\"five\":\"2013-03-27T23:18:40Z\"}");
+
+    JSONObject result = (JSONObject) instance.deserialize(w);
+
+    StructObjectInspector soi = (StructObjectInspector) instance.getObjectInspector();
+
+    JavaStringTimestampObjectInspector jstOi = (JavaStringTimestampObjectInspector)
             soi.getStructFieldRef("five").getFieldObjectInspector();
     assertEquals(Timestamp.valueOf("2013-03-27 23:18:40.0"), jstOi.getPrimitiveJavaObject(result.get("five")));
   }
@@ -125,5 +140,9 @@ public class JsonSerDeTimeStampTest {
       
   }
 
-
+  @Test
+  public void testformatDateFromUTC() throws ParseException {
+    String string1 = "2001-07-04T12:08:56Z";
+    assertEquals("2001-07-04 12:08:56", ParsePrimitiveUtils.nonUTCFormat(string1));
+  }
 }


### PR DESCRIPTION
When trying to import JSON data which has dates in UTC (ISO 8601) date format it error out. Added code to format the date to non ISO 8601.
UTC: "2014-07-10T11:47:45Z"
NON UTC: "2014-07-10 11:47:45" (Without "T" and "Z" chars)
Error Message: java.io.IOException: java.lang.IllegalArgumentException: Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
