### PR TITLE
[add]: Added try/catches

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
@@ -19,50 +19,70 @@ public class ParsePrimitiveUtils {
     }
 
     public static byte parseByte(String s) {
-        if (isHex(s)) {
-            return Byte.parseByte(s.substring(2), 16);
-        } else {
-            return Byte.parseByte(s);
+        try {
+            if (isHex(s)) {
+                return Byte.parseByte(s.substring(2), 16);
+            } else {
+                return Byte.parseByte(s);
+            }
+        } catch (NumberFormatException e) {
+            return 0;
         }
     }
 
     public static int parseInt(String s) {
-        if (isHex(s)) {
-            return Integer.parseInt(s.substring(2), 16);
-        } else {
-            return Integer.parseInt(s);
+        try {
+            if (isHex(s)) {
+                return Integer.parseInt(s.substring(2), 16);
+            } else {
+                return Integer.parseInt(s);
+            }
+        } catch (NumberFormatException e) {
+            return 0;
         }
     }
 
     public static short parseShort(String s) {
-        if (isHex(s)) {
-            return Short.parseShort(s.substring(2), 16);
-        } else {
-            return Short.parseShort(s);
+        try {
+            if (isHex(s)) {
+                return Short.parseShort(s.substring(2), 16);
+            } else {
+                return Short.parseShort(s);
+            }
+        } catch (NumberFormatException e) {
+            return 0;
         }
     }
 
     public static long parseLong(String s) {
-        if (isHex(s)) {
-            return Long.parseLong(s.substring(2), 16);
-        } else {
-            return Long.parseLong(s);
+        try {
+            if (isHex(s)) {
+                return Long.parseLong(s.substring(2), 16);
+            } else {
+                return Long.parseLong(s);
+            }
+        } catch (NumberFormatException e) {
+            return 0l;
         }
     }
 
     public static Timestamp parseTimestamp(String s) {
-        Timestamp value;
-        if (s.indexOf(':') > 0) {
-            value = Timestamp.valueOf(s);
-        } else if (s.indexOf('.') >= 0) {
-            // it's a float
-            value = new Timestamp(
-                    (long) ((double) (Double.parseDouble(s) * 1000)));
-        } else {
-            // integer 
-            value = new Timestamp(Long.parseLong(s) * 1000);
+        try {
+            Timestamp value;
+            if (s.indexOf(':') > 0) {
+                value = Timestamp.valueOf(s);
+            } else if (s.indexOf('.') >= 0) {
+                // it's a float
+                value = new Timestamp(
+                        (long) ((double) (Double.parseDouble(s) * 1000)));
+            } else {
+                // integer
+                value = new Timestamp(Long.parseLong(s) * 1000);
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            return new Timestamp(0l);
         }
-        return value;
     }
 
 }


### PR DESCRIPTION
Handle invalid primitives in json:


Problem we experience quite often:
```
dfs -rm -f -r /tmp/err_test;
dfs -mkdir /tmp/err_test;
drop table if exists err_test;
drop table if exists err_string_test;
--add  jar /tmp/json-serde-1.3.7-SNAPSHOT-jar-with-dependencies.jar;
create external table err_test(a int) ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe' location '/tmp/err_test/';
create external table err_string_test(a string) location '/tmp/err_test/';
insert into err_string_test VALUES('{"a" :"not_an_int"}'),('{"a" :"1"}');
select * from err_string_test order by a LIMIT 10;  --this will go through
select * from err_test order by a LIMIT 10;  -- this will fail
```

Looking at the code and exception stack trace, 

```
Diagnostic Messages for this Task:
Error: java.lang.RuntimeException: org.apache.hadoop.hive.ql.metadata.HiveException: Hive Runtime Error while processing row [Error getting row data with exception java.lang.NumberFormatException: For input string: "not_an_int"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.openx.data.jsonserde.objectinspector.primitive.ParsePrimitiveUtils.parseInt(ParsePrimitiveUtils.java:33)
	at org.openx.data.jsonserde.objectinspector.primitive.JavaStringIntObjectInspector.get(JavaStringIntObjectInspector.java:45)
	at org.apache.hadoop.hive.serde2.SerDeUtils.buildJSONString(SerDeUtils.java:226)
	at org.apache.hadoop.hive.serde2.SerDeUtils.buildJSONString(SerDeUtils.java:354)
	at org.apache.hadoop.hive.serde2.SerDeUtils.getJSONString(SerDeUtils.java:198)
	at org.apache.hadoop.hive.serde2.SerDeUtils.getJSONString(SerDeUtils.java:184)
	at org.apache.hadoop.hive.ql.exec.MapOperator.toErrorMessage(MapOperator.java:544)
	at org.apache.hadoop.hive.ql.exec.MapOperator.process(MapOperator.java:513)
	at org.apache.hadoop.hive.ql.exec.mr.ExecMapper.map(ExecMapper.java:163)
	at org.apache.hadoop.mapred.MapRunner.run(MapRunner.java:54)
	at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:453)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:343)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1657)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
 ]
	at org.apache.hadoop.hive.ql.exec.mr.ExecMapper.map(ExecMapper.java:172)
	at org.apache.hadoop.mapred.MapRunner.run(MapRunner.java:54)
	at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:453)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:343)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1657)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: Hive Runtime Error while processing row [Error getting row data with exception java.lang.NumberFormatException: For input string: "not_an_int"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.openx.data.jsonserde.objectinspector.primitive.ParsePrimitiveUtils.parseInt(ParsePrimitiveUtils.java:33)
	at org.openx.data.jsonserde.objectinspector.primitive.JavaStringIntObjectInspector.get(JavaStringIntObjectInspector.java:45)
	at org.apache.hadoop.hive.serde2.SerDeUtils.buildJSONString(SerDeUtils.java:226)
	at org.apache.hadoop.hive.serde2.SerDeUtils.buildJSONString(SerDeUtils.java:354)
	at org.apache.hadoop.hive.serde2.SerDeUtils.getJSONString(SerDeUtils.java:198)
	at org.apache.hadoop.hive.serde2.SerDeUtils.getJSONString(SerDeUtils.java:184)
	at org.apache.hadoop.hive.ql.exec.MapOperator.toErrorMessage(MapOperator.java:544)
	at org.apache.hadoop.hive.ql.exec.MapOperator.process(MapOperator.java:513)
	at org.apache.hadoop.hive.ql.exec.mr.ExecMapper.map(ExecMapper.java:163)
	at org.apache.hadoop.mapred.MapRunner.run(MapRunner.java:54)
	at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:453)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:343)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1657)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
 ]
	at org.apache.hadoop.hive.ql.exec.MapOperator.process(MapOperator.java:518)
	at org.apache.hadoop.hive.ql.exec.mr.ExecMapper.map(ExecMapper.java:163)
	... 8 more
Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: java.lang.NumberFormatException: For input string: "not_an_int"
	at org.apache.hadoop.hive.ql.exec.ReduceSinkOperator.process(ReduceSinkOperator.java:403)
	at org.apache.hadoop.hive.ql.exec.Operator.forward(Operator.java:837)
	at org.apache.hadoop.hive.ql.exec.SelectOperator.process(SelectOperator.java:88)
	at org.apache.hadoop.hive.ql.exec.Operator.forward(Operator.java:837)
	at org.apache.hadoop.hive.ql.exec.TableScanOperator.process(TableScanOperator.java:97)
	at org.apache.hadoop.hive.ql.exec.MapOperator$MapOpCtx.forward(MapOperator.java:162)
	at org.apache.hadoop.hive.ql.exec.MapOperator.process(MapOperator.java:508)
	... 9 more
Caused by: java.lang.NumberFormatException: For input string: "not_an_int"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.openx.data.jsonserde.objectinspector.primitive.ParsePrimitiveUtils.parseInt(ParsePrimitiveUtils.java:33)
	at org.openx.data.jsonserde.objectinspector.primitive.JavaStringIntObjectInspector.get(JavaStringIntObjectInspector.java:45)
	at org.apache.hadoop.hive.serde2.binarysortable.BinarySortableSerDe.serialize(BinarySortableSerDe.java:682)
	at org.apache.hadoop.hive.serde2.binarysortable.BinarySortableSerDe.serialize(BinarySortableSerDe.java:631)
	at org.apache.hadoop.hive.ql.exec.ReduceSinkOperator.toHiveKey(ReduceSinkOperator.java:507)
	at org.apache.hadoop.hive.ql.exec.ReduceSinkOperator.process(ReduceSinkOperator.java:355)
	... 15 more
```

and relevant codes

MapOperator.java:process
```
for (MapOpCtx current : currentCtxs) {
      Object row = null;
      try {
        row = current.readRow(value, context);
        if (!current.forward(row)) {
          childrenDone++;
        }
      } catch (Exception e) {
        // TODO: policy on deserialization errors
        String message = toErrorMessage(value, row, current.rowObjectInspector);
        if (row == null) {
          deserialize_error_count.set(deserialize_error_count.get() + 1);
          throw new HiveException("Hive Runtime Error while processing writable " + message, e);
        }
        throw new HiveException("Hive Runtime Error while processing row " + message, e);
      }
    }
```
my understanding is that currently there is no way to catch these exceptions via configuration options (e.g. mapreduce.job.skiprecords). 
The only thing that seems viable is to catch these kind of problems using try/catch within methods of ParsePrimitiveUtils.
I understand this is probably the ugliest solution and a better pattern might be to pre-validate json, but unfortunately this doesn't seem to be a feasible situation in our case.

I will be pleased if you merge this PR, however I understand that this is not the ideal situation and you might not accept it.
In any case, I am open to your suggestions regarding this.