### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/json-serde-cdh5-shim/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDateObjectInspector.java
+++ b/json-serde-cdh5-shim/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDateObjectInspector.java
@@ -44,7 +44,7 @@ public class JavaStringDateObjectInspector  extends AbstractPrimitiveJavaObjectI
         if(o instanceof String) {
             return new DateWritable(parse((String)o));
         } else {
-            return new DateWritable(((Date) o));
+            return new DateWritable((Date) o);
         }
     }
 
@@ -53,7 +53,7 @@ public class JavaStringDateObjectInspector  extends AbstractPrimitiveJavaObjectI
         if(o instanceof String) {
            parse((String)o);
         } else {
-            if (o instanceof Date) return ((Date) o);
+            if (o instanceof Date) return (Date) o;
         }
         return null;
     }

--- a/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
@@ -109,7 +109,7 @@ public class JsonSerDe implements SerDe {
         } else {
             columnTypes = TypeInfoUtils.getTypeInfosFromTypeString(columnTypeProperty);
         }
-        assert (columnNames.size() == columnTypes.size());
+        assert columnNames.size() == columnTypes.size();
 
         stats = new SerDeStats();
 
@@ -128,8 +128,8 @@ public class JsonSerDe implements SerDe {
         String columnSortOrder = tbl.getProperty(Constants.SERIALIZATION_SORT_ORDER);
         columnSortOrderIsDesc = new boolean[columnNames.size()];
         for (int i = 0; i < columnSortOrderIsDesc.length; i++) {
-            columnSortOrderIsDesc[i] = (columnSortOrder != null && 
-                    columnSortOrder.charAt(i) == '-');
+            columnSortOrderIsDesc[i] = columnSortOrder != null && 
+                    columnSortOrder.charAt(i) == '-';
         }
         
         
@@ -222,7 +222,7 @@ public class JsonSerDe implements SerDe {
     }
 
     private String getSerializedFieldName( List<String> columnNames, int pos, StructField sf) {
-        String n = (columnNames==null? sf.getFieldName(): columnNames.get(pos));
+        String n = columnNames==null? sf.getFieldName(): columnNames.get(pos);
         
         if(options.getMappings().containsKey(n)) {
             return options.getMappings().get(n);
@@ -291,30 +291,30 @@ public class JsonSerDe implements SerDe {
                         result = null;
                         break;
                     case BOOLEAN:
-                        result = (((BooleanObjectInspector)poi).get(obj)?
+                        result = ((BooleanObjectInspector)poi).get(obj)?
                                             Boolean.TRUE:
-                                            Boolean.FALSE);
+                                            Boolean.FALSE;
                         break;
                     case BYTE:
-                        result = (((ByteObjectInspector)poi).get(obj));
+                        result = ((ByteObjectInspector)poi).get(obj);
                         break;
                     case DOUBLE:
-                        result = (((DoubleObjectInspector)poi).get(obj));
+                        result = ((DoubleObjectInspector)poi).get(obj);
                         break;
                     case FLOAT:
-                        result = (((FloatObjectInspector)poi).get(obj));
+                        result = ((FloatObjectInspector)poi).get(obj);
                         break;
                     case INT:
-                        result = (((IntObjectInspector)poi).get(obj));
+                        result = ((IntObjectInspector)poi).get(obj);
                         break;
                     case LONG:
-                        result = (((LongObjectInspector)poi).get(obj));
+                        result = ((LongObjectInspector)poi).get(obj);
                         break;
                     case SHORT:
-                        result = (((ShortObjectInspector)poi).get(obj));
+                        result = ((ShortObjectInspector)poi).get(obj);
                         break;
                     case STRING:
-                        result = (((StringObjectInspector)poi).getPrimitiveJavaObject(obj));
+                        result = ((StringObjectInspector)poi).getPrimitiveJavaObject(obj);
                         break;
                     case UNKNOWN:
                         throw new RuntimeException("Unknown primitive");

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonObjectInspectorUtils.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonObjectInspectorUtils.java
@@ -29,7 +29,7 @@ public class JsonObjectInspectorUtils {
       
       if(data instanceof String ||
          data instanceof Text) {
-          String str = (data instanceof String ? (String)data : ((Text)data).toString() );
+          String str = data instanceof String ? (String)data : ((Text)data).toString();
           if(str.trim().isEmpty())
             return null;
       }

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonStructObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonStructObjectInspector.java
@@ -98,7 +98,7 @@ public class JsonStructObjectInspector extends StandardStructObjectInspector {
         MyField f = (MyField) fieldRef;
 
         int fieldID = f.getFieldID();
-        assert (fieldID >= 0 && fieldID < fields.size());
+        assert fieldID >= 0 && fieldID < fields.size();
 
         Object fieldData = null;
         

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringBooleanObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringBooleanObjectInspector.java
@@ -35,7 +35,7 @@ public class JavaStringBooleanObjectInspector extends AbstractPrimitiveJavaObjec
     if(o instanceof String) {
       return new BooleanWritable(Boolean.parseBoolean((String) o));
     } else {
-      return new BooleanWritable(((Boolean) o));
+      return new BooleanWritable((Boolean) o);
     }
   }
 
@@ -45,7 +45,7 @@ public class JavaStringBooleanObjectInspector extends AbstractPrimitiveJavaObjec
     if(o instanceof String) {
       return Boolean.parseBoolean((String) o);
     } else {
-      return (((Boolean) o));
+      return (Boolean) o;
     }
   }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringByteObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringByteObjectInspector.java
@@ -44,7 +44,7 @@ public  class JavaStringByteObjectInspector
         if(o instanceof String) {
            return ParsePrimitiveUtils.parseByte((String)o); 
         } else {
-           return ((Byte) o);
+           return (Byte) o;
         }
     }
 
@@ -56,7 +56,7 @@ public  class JavaStringByteObjectInspector
 
     @Override
     public Object create(byte value) {
-        return (value);
+        return value;
     }
 
     @Override

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDoubleObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDoubleObjectInspector.java
@@ -34,7 +34,7 @@ public class JavaStringDoubleObjectInspector extends AbstractPrimitiveJavaObject
         if(o instanceof String) {
            return new DoubleWritable(Double.parseDouble((String)o)); 
         } else {
-          return new DoubleWritable(((Double) o));
+          return new DoubleWritable((Double) o);
         }
     }
 
@@ -44,7 +44,7 @@ public class JavaStringDoubleObjectInspector extends AbstractPrimitiveJavaObject
         if(o instanceof String) {
            return Double.parseDouble((String)o); 
         } else {
-          return (((Double) o));
+          return (Double) o;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringFloatObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringFloatObjectInspector.java
@@ -43,7 +43,7 @@ public class JavaStringFloatObjectInspector extends AbstractPrimitiveJavaObjectI
         if(o instanceof String) {
           return Float.parseFloat((String)o); 
         } else {
-          return ((Float) o);
+          return (Float) o;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringIntObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringIntObjectInspector.java
@@ -44,7 +44,7 @@ public class JavaStringIntObjectInspector
         if(o instanceof String) {
            return ParsePrimitiveUtils.parseInt((String)o); 
         } else {
-           return ((Integer) o);
+           return (Integer) o;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringLongObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringLongObjectInspector.java
@@ -45,7 +45,7 @@ public class JavaStringLongObjectInspector
         if(o instanceof String) {
            return ParsePrimitiveUtils.parseLong((String)o);
         } else {
-          return ((Long) o);
+          return (Long) o;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringShortObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringShortObjectInspector.java
@@ -45,7 +45,7 @@ public class JavaStringShortObjectInspector
         if(o instanceof String) {
            return ParsePrimitiveUtils.parseShort((String)o); 
         } else {
-          return ((Short) o);
+          return (Short) o;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringTimestampObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringTimestampObjectInspector.java
@@ -61,7 +61,7 @@ public class JavaStringTimestampObjectInspector extends AbstractPrimitiveJavaObj
         if(o instanceof String) {
            return new TimestampWritable(ParsePrimitiveUtils.parseTimestamp((String)o)); 
         } else {
-          return new TimestampWritable(((Timestamp) o));
+          return new TimestampWritable((Timestamp) o);
         }
     }
 
@@ -70,7 +70,7 @@ public class JavaStringTimestampObjectInspector extends AbstractPrimitiveJavaObj
          if(o instanceof String) {
            return ParsePrimitiveUtils.parseTimestamp((String)o); 
         } else {
-           return ((Timestamp) o);
+           return (Timestamp) o;
         }
     }
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JsonStringJavaObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JsonStringJavaObjectInspector.java
@@ -31,7 +31,7 @@ public class JsonStringJavaObjectInspector extends
 
   @Override
   public Text getPrimitiveWritableObject(Object o) {
-    return o == null ? null : new Text(((String) o.toString()));
+    return o == null ? null : new Text((String) o.toString());
   }
 
   @Override

--- a/json-udf/src/main/java/org/openx/data/udf/JsonUDF.java
+++ b/json-udf/src/main/java/org/openx/data/udf/JsonUDF.java
@@ -66,7 +66,7 @@ public class JsonUDF extends GenericUDF {
 
     @Override
     public String getDisplayString(String[] children) {
-        assert (children.length > 0);
+        assert children.length > 0;
 
         StringBuilder sb = new StringBuilder();
         sb.append("JsonUDF(");

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -968,7 +968,7 @@ public class JSONObject {
 
         boolean includeSuperClass = klass.getClassLoader() != null;
 
-        Method[] methods = (includeSuperClass) ?
+        Method[] methods = includeSuperClass ?
                 klass.getMethods() : klass.getDeclaredMethods();
         for (int i = 0; i < methods.length; i += 1) {
             try {

--- a/json/src/main/java/org/openx/data/jsonserde/json/XML.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/XML.java
@@ -330,7 +330,7 @@ public class XML {
 	        if (initial == '0' && string.charAt(negative ? 2 : 1) == '0') {
 	        	return string;
 	        }
-	        if ((initial >= '0' && initial <= '9')) {
+	        if (initial >= '0' && initial <= '9') {
                 if (string.indexOf('.') >= 0) {
                     return Double.valueOf(string);
                 } else if (string.indexOf('e') < 0 && string.indexOf('E') < 0) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava