### PR TITLE
squid:S2583 - Conditions should not unconditionally evaluate to TRUE or to FALSE

### DIFF
--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -114,10 +114,10 @@ public class JSONObject {
          */
         @Override
         public boolean equals(Object object) {
-            if(! (object instanceof JSONObject)) {
+            if(object == null || !(object instanceof JSONObject)) {
                 return false;
             } else {
-                return object == null || object == this;
+                return object == this;
             }
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2583 - Conditions should not unconditionally evaluate to TRUE or to FALSE.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2583
Please let me know if you have any questions.
George Kankava