### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonObjectInspectorFactory.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonObjectInspectorFactory.java
@@ -27,9 +27,13 @@ import org.openx.data.jsonserde.objectinspector.primitive.*;
  *
  * @author rcongiu
  */
-public class JsonObjectInspectorFactory {
+public final class JsonObjectInspectorFactory {
 
     static HashMap<TypeInfo, ObjectInspector> cachedJsonObjectInspector = new HashMap<TypeInfo, ObjectInspector>();
+
+    private JsonObjectInspectorFactory() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
 
     /**
      *

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonObjectInspectorUtils.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonObjectInspectorUtils.java
@@ -22,7 +22,12 @@ import org.apache.hadoop.io.Text;
  *
  * @author rcongiu
  */
-public class JsonObjectInspectorUtils {
+public final class JsonObjectInspectorUtils {
+
+    private JsonObjectInspectorUtils() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
+
       public static Object checkObject(Object data) {
       // just check for null first thing
       if(data == null) return data;

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
@@ -12,7 +12,12 @@ import org.apache.hadoop.hive.serde2.io.TimestampWritable;
  *
  * @author rcongiu
  */
-public class ParsePrimitiveUtils {
+public final class ParsePrimitiveUtils {
+
+    private ParsePrimitiveUtils() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
+
     public static boolean isHex(String s) {
         return s.startsWith("0x") || s.startsWith("0X");
     }

--- a/json/src/main/java/org/openx/data/jsonserde/json/CDL.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/CDL.java
@@ -43,7 +43,11 @@ SOFTWARE.
  * @author JSON.org
  * @version 2010-12-24
  */
-public class CDL {
+public final class CDL {
+
+    private CDL() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
 
     /**
      * Get the next value. The value can be wrapped in quotes. The value can

--- a/json/src/main/java/org/openx/data/jsonserde/json/Cookie.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/Cookie.java
@@ -30,7 +30,11 @@ SOFTWARE.
  * @author JSON.org
  * @version 2010-12-24
  */
-public class Cookie {
+public final class Cookie {
+
+    private Cookie() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
 
     /**
      * Produce a copy of a string in which the characters '+', '%', '=', ';'

--- a/json/src/main/java/org/openx/data/jsonserde/json/CookieList.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/CookieList.java
@@ -31,7 +31,11 @@ import java.util.Iterator;
  * @author JSON.org
  * @version 2010-12-24
  */
-public class CookieList {
+public final class CookieList {
+
+    private CookieList() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
 
     /**
      * Convert a cookie list into a JSONObject. A cookie list is a sequence

--- a/json/src/main/java/org/openx/data/jsonserde/json/HTTP.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/HTTP.java
@@ -31,10 +31,14 @@ import java.util.Iterator;
  * @author JSON.org
  * @version 2010-12-24
  */
-public class HTTP {
+public final class HTTP {
 
     /** Carriage return/line feed. */
     public static final String CRLF = "\r\n";
+
+    private HTTP() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
 
     /**
      * Convert an HTTP header string into a JSONObject. It can be a request

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONML.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONML.java
@@ -34,8 +34,12 @@ import java.util.Iterator;
  * @author JSON.org
  * @version 2010-12-23
  */
-public class JSONML {
-		
+public final class JSONML {
+
+    private JSONML() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
+
     /**
      * Parse XML values and store them in a JSONArray.
      * @param x       The XMLTokener containing the source string.

--- a/json/src/main/java/org/openx/data/jsonserde/json/XML.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/XML.java
@@ -33,7 +33,7 @@ import java.util.Iterator;
  * @author JSON.org
  * @version 2011-02-11
  */
-public class XML {
+public final class XML {
 
     /** The Character '&'. */
     public static final Character AMP   = new Character('&');
@@ -61,6 +61,10 @@ public class XML {
 
     /** The Character '/'. */
     public static final Character SLASH = new Character('/');
+
+    private XML() {
+        throw new InstantiationError("This class must not be instantiated.");
+    }
 
     /**
      * Replace special characters with XML escapes:


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
Please let me know if you have any questions.
George Kankava