### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
@@ -323,6 +323,8 @@ public class JsonSerDe implements SerDe {
                         break;
                     case UNKNOWN:
                         throw new RuntimeException("Unknown primitive");
+                    default:
+                        break;
                 }
                 break;
             case MAP:
@@ -336,6 +338,8 @@ public class JsonSerDe implements SerDe {
                 break;
             case UNION:
                 result = serializeUnion(obj, (UnionObjectInspector)oi);
+            default:
+                break;
         }
         return result;
     }

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONTokener.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONTokener.java
@@ -375,6 +375,8 @@ public class JSONTokener {
             case '[':
                 back();
                 return new JSONArray(this);
+            default:
+                break;
         }
 
 

--- a/json/src/main/java/org/openx/data/jsonserde/json/XMLTokener.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/XMLTokener.java
@@ -202,6 +202,8 @@ public class XMLTokener extends JSONTokener {
                 case '\'':
                     back();
                     return Boolean.TRUE;
+                default:
+                    break;
                 }
             }
         }
@@ -286,6 +288,8 @@ public class XMLTokener extends JSONTokener {
                 case '"':
                 case '\'':
                     throw syntaxError("Bad character in a name");
+                default:
+                    break;
                 }
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ASwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava