### PR TITLE
Support for ISO8601 date(time) strings

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
@@ -58,12 +58,23 @@ public final class ParsePrimitiveUtils {
         final String sampleUnixTimestampInMs = "1454612111000";
 
         Timestamp value;
-        if (s.indexOf(':') > 0) {
+        //DateISO8601 Format Acceptance
+        String datePattern = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]";
+
+        if (s == null || s.length() == 0) {
+            return null;
+        }
+
+        if(s.contains("T")) {
+            value = new Timestamp(javax.xml.bind.DatatypeConverter.parseDateTime(s).getTimeInMillis());
+        } else if (s.indexOf(':') > 0) {
             value = Timestamp.valueOf(s);
+        } else if(s.matches(datePattern)){
+            value = new Timestamp(javax.xml.bind.DatatypeConverter.parseDate(s).getTimeInMillis());
         } else if (s.indexOf('.') >= 0) {
             // it's a float
             value = new Timestamp(
-                    (long) ((double) (Double.parseDouble(s) * 1000)));
+                (long) ((double) (Double.parseDouble(s) * 1000)));
         } else {
             // integer 
             Long timestampValue = Long.parseLong(s);
@@ -72,9 +83,10 @@ public final class ParsePrimitiveUtils {
                 value = new Timestamp(timestampValue);
             } else {
                 value = new Timestamp(timestampValue * 1000);
-            }            
+            }
         }
-        return value;
+        
+        return value;        
     }
 
 }

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTimeStampTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTimeStampTest.java
@@ -91,7 +91,7 @@ public class JsonSerDeTimeStampTest {
      StructObjectInspector soi = (StructObjectInspector) instance.getObjectInspector();
     JavaStringTimestampObjectInspector jstOi = (JavaStringTimestampObjectInspector) 
             soi.getStructFieldRef("five").getFieldObjectInspector();
-    assertEquals(getDate("2013-05-05 17:58:45.0" ), 
+    assertEquals(getDate("2013-05-05 17:58:45.0"),
             jstOi.getPrimitiveJavaObject(result.get("five"))   );
   }
 
@@ -120,7 +120,49 @@ public class JsonSerDeTimeStampTest {
     assertEquals(getDate("2013-05-05 17:58:45.123"), 
             jstOi.getPrimitiveJavaObject(result.get("five")) );
   }
+
+  @Test
+  public void testIso8601TimestampDeSerialize() throws Exception {
+    // Test that timestamp object can be deserialized
+    Writable w = new Text("{\"one\":true,\"five\":\"2015-02-07T00:51:52.382975\"}");
+
+    JSONObject result = (JSONObject) instance.deserialize(w);
+
+    StructObjectInspector soi = (StructObjectInspector) instance.getObjectInspector();
+
+    JavaStringTimestampObjectInspector jstOi = (JavaStringTimestampObjectInspector)
+        soi.getStructFieldRef("five").getFieldObjectInspector();
+    assertEquals(Timestamp.valueOf("2015-02-07 00:51:52.382"), jstOi.getPrimitiveJavaObject(result.get("five")));
+  }
   
+  @Test
+  public void testIso8601TimestampUtcDeSerialize() throws Exception {
+    // Test that timestamp object can be deserialized
+    Writable w = new Text("{\"one\":true,\"five\":\"2015-02-07T00:51:52.382975Z\"}");
+
+    JSONObject result = (JSONObject) instance.deserialize(w);
+
+    StructObjectInspector soi = (StructObjectInspector) instance.getObjectInspector();
+
+    JavaStringTimestampObjectInspector jstOi = (JavaStringTimestampObjectInspector)
+        soi.getStructFieldRef("five").getFieldObjectInspector();
+    assertEquals(new Timestamp(1423270312382l), jstOi.getPrimitiveJavaObject(result.get("five")));
+  }  
+
+  @Test
+  public void testIso8601TimestampDeSerializeEmptyString() throws Exception {
+    // Test that timestamp object can be deserialized
+    Writable w = new Text("{\"one\":true,\"five\":\"\"}");
+
+    JSONObject result = (JSONObject) instance.deserialize(w);
+
+    StructObjectInspector soi = (StructObjectInspector) instance.getObjectInspector();
+
+    JavaStringTimestampObjectInspector jstOi = (JavaStringTimestampObjectInspector)
+        soi.getStructFieldRef("five").getFieldObjectInspector();
+    assertEquals(null, jstOi.getPrimitiveJavaObject(result.get("five")));
+  }
+
   /** 
    * for tests, if time zone not specified, make sure that it's in the correct
    * timezone


### PR DESCRIPTION
This PR is based on 'prezi/iso8601changes' and only includes the changes relevant for the ISO8601 parsing.
I added a test for timestamps in UTC timezone.