### PR TITLE
Changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+### 1.3.8 (Next)
+
+* [#131](https://github.com/rcongiu/Hive-JSON-Serde/issues/131): Added support for mapping json keys with periods - [@rcongiu](https://github.com/rcongiu).
+* [#148](https://github.com/rcongiu/Hive-JSON-Serde/pull/148): Fix: for `String` type input, `JavaStringDateObjectInspector#getPrimitiveJavaObject` should not return `null` - [@wangxianbin1987](https://github.com/wangxianbin1987).
+* [#135](https://github.com/rcongiu/Hive-JSON-Serde/pull/135), [#134](https://github.com/rcongiu/Hive-JSON-Serde/pull/134), [#132](https://github.com/rcongiu/Hive-JSON-Serde/pull/132), [#130](https://github.com/rcongiu/Hive-JSON-Serde/pull/130), [#129](https://github.com/rcongiu/Hive-JSON-Serde/pull/129): Fix Sonar warnings - [@georgekankava](https://github.com/georgekankava).
+* [#128](https://github.com/rcongiu/Hive-JSON-Serde/pull/128): Added support for timestamps in milliseconds - [@kevinstumpf](https://github.com/kevinstumpf).
+* [#102](https://github.com/rcongiu/Hive-JSON-Serde/pull/102): When empty string appears where a Hive Map (JSON Object) was expected, treat it as NULL, not -1 - [@mhandwerker](https://github.com/mhandwerker).
+* [#12](https://github.com/rcongiu/Hive-JSON-Serde/issues/12): If a field is declared an array but a scalar is found, coerce it - [@rcongiu](https://github.com/rcongiu).
+
+### 1.3.7 (2015/12/10)
+
+* Added JSON UDF - [@rcongiu](https://github.com/rcongiu).
+* Added support for DATE type (Hive 1.2.0 and higher) - [@rcongiu](https://github.com/rcongiu).
+
+### 1.3.6 (2015/10/08)
+
+* [#117](https://github.com/rcongiu/Hive-JSON-Serde/pull/117): Added support for HDP 2.3 - [@dajobe](https://github.com/dajobe).
+* [#118](https://github.com/rcongiu/Hive-JSON-Serde/pull/118): Added support for String to Boolean conversion - [@rjainqb](https://github.com/rjainqb).
+* [#116](https://github.com/rcongiu/Hive-JSON-Serde/issues/116): Updated docs - [@rcongiu](https://github.com/rcongiu).
+
+### 1.3.5 (2015/08/30)
+
+* Made CDH5 default - [@rcongiu](https://github.com/rcongiu).
+* [#53](https://github.com/rcongiu/Hive-JSON-Serde/issues/53): Added `UNIONTYPE` support - [@rcongiu](https://github.com/rcongiu).
+* [#112](https://github.com/rcongiu/Hive-JSON-Serde/issues/112): Handle empty array where an empty object should be - [@rcongiu](https://github.com/rcongiu).
+* [#98](https://github.com/rcongiu/Hive-JSON-Serde/pull/98): Added missing getPrimitiveJavaObject implementations - [@y-lan](https://github.com/y-lan).
+
+### 1.3 (2014/09/08)
+
+* [#82](https://github.com/rcongiu/Hive-JSON-Serde/issues/82): Fixed parsing empty strings to `map(string, string)` - [@rcongiu](https://github.com/rcongiu).
+* [#84](https://github.com/rcongiu/Hive-JSON-Serde/issues/84): Deep name mapping - [@rcongiu](https://github.com/rcongiu).
+* [#83](https://github.com/rcongiu/Hive-JSON-Serde/pull/83): - Fix for `\a` or `\v` that Java does not recognize in strings - [@ptrstpp950](https://github.com/ptrstpp950).
+* [#86](https://github.com/rcongiu/Hive-JSON-Serde/pull/86): - Fix `PrimitiveObjectInspector#getPrimitiveJavaObject(Object)` - [@andykram](https://github.com/andykram).
+
+### 1.2 (2014/06/01)
+
+* Refactored to multimodule for CDH5 compatibility - [@rcongiu](https://github.com/rcongiu).
+* [#90](https://github.com/rcongiu/Hive-JSON-Serde/pull/90): Fix `get_json_object` on Json String unless one defines it as struct - [@moss](https://github.com/wmoss).
+* [#68](https://github.com/rcongiu/Hive-JSON-Serde/pull/68): Custom primitive object inspectors in the Serde need to override `getPrimitiveJavaObject` - [@appanasatya](https://github.com/appanasatya).
+
+### 1.1.9.2 (2014/02/25)
+
+* Added support for array records - [@rcongiu](https://github.com/rcongiu).
+* Refactored timestamp handling - [@rcongiu](https://github.com/rcongiu).
+* [#50](https://github.com/rcongiu/Hive-JSON-Serde/issues/50): Fixed issue with `{ field = null }` - [@rcongiu](https://github.com/rcongiu).
+* [#54](https://github.com/rcongiu/Hive-JSON-Serde/issues/54): Fixed handling of `null` in arrays - [@rcongiu](https://github.com/rcongiu).
+* [#55](https://github.com/rcongiu/Hive-JSON-Serde/pull/55): Fixed wrong cast - [@Powerrr](https://github.com/Powerrr).
+* [#52](https://github.com/rcongiu/Hive-JSON-Serde/pull/52): Fixed `tynyint/byte` type - [@Powerrr](https://github.com/Powerrr).
+
+### 1.1.9.1 (2014/02/02)
+
+* Fixed wrong type (`long`) in `JavaStringIntObjectInspector` - [@rcongiu](https://github.com/rcongiu).
+* [#22](https://github.com/rcongiu/Hive-JSON-Serde/pull/22): Verify castability - [@elreydetodo](https://github.com/elreydetodo).
+
+### 1.1.8 (2014/01/22)
+
+* Rewritten handling of numbers, so their parsing from string is delayed - [@rcongiu](https://github.com/rcongiu).
+* [#39](https://github.com/rcongiu/Hive-JSON-Serde/issues/39): Fixed `testTimestampDeSerializeNumericTimestampWithNanoseconds` in different timezones - [@rcongiu](https://github.com/rcongiu).
+* [#45](https://github.com/rcongiu/Hive-JSON-Serde/issues/45): Fixed `String` cannot be cast to `Integer` - [@rcongiu](https://github.com/rcongiu).
+* [#34](https://github.com/rcongiu/Hive-JSON-Serde/issues/34): Fixed `Integer` cannot be cast to `Long` - [@rcongiu](https://github.com/rcongiu).
+* [#43](https://github.com/rcongiu/Hive-JSON-Serde/issues/43): Fixed escape characters handling - [@rcongiu](https://github.com/rcongiu).
+* [#29](https://github.com/rcongiu/Hive-JSON-Serde/issues/29): Fixed double cast - [@rcongiu](https://github.com/rcongiu).
+* [#26](https://github.com/rcongiu/Hive-JSON-Serde/issues/26): Fixed `Integer` cannot be cast to `Double` - [@rcongiu](https://github.com/rcongiu).
+* [#13](https://github.com/rcongiu/Hive-JSON-Serde/issues/13): Support Hive `FLOAT` - [@rcongiu](https://github.com/rcongiu).
+* [#40](https://github.com/rcongiu/Hive-JSON-Serde/pull/40): Fixed `JSONObject#equals` - [@leobispo](https://github.com/leobispo).
+
+### 1.1.7 (2013/09/30)
+
+* [#31](https://github.com/rcongiu/Hive-JSON-Serde/issues/31): Fixed static members not to be - [@rcongiu](https://github.com/rcongiu).
+* [#25](https://github.com/rcongiu/Hive-JSON-Serde/issues/25): Added basic timestamp support in deserializer - [@rcongiu](https://github.com/rcongiu), [@guyrt](https://github.com/guyrt).
+
+### 1.1.6 (2013/07/10)
+
+* [#28](https://github.com/rcongiu/Hive-JSON-Serde/issues/28): Fixed error after `ALTER TABLE ADD COLUMNS` - [@rcongiu](https://github.com/rcongiu), [@brndnmtthws](https://github.com/brndnmtthws).
+
+### 1.1.4 (2012/10/04)
+
+* [#13](https://github.com/rcongiu/Hive-JSON-Serde/issues/13): Problem with floats - [@rcongiu](https://github.com/rcongiu), [@ChuckConnell](https://github.com/ChuckConnell).
+* [#7](https://github.com/rcongiu/Hive-JSON-Serde/pull/7): Fix handling of `{ arrayProp: null }` when expecting `{ arrayProp:[] }` - [@peterdm](https://github.com/peterdm).
+
+### 1.1.2 (2012/07/26)
+
+* Fixed columns not mapped into JSON - [@rcongiu](https://github.com/rcongiu), [@pmohan6](https://github.com/pmohan6).
+
+### 1.1.1 (2012/07/03)
+
+* Fixed infinite loop in `MapAdapter` - [@rcongiu](https://github.com/rcongiu).
+
+### 1.1 (2011/09/09)
+
+* Fixed 'string' type to accept non-string data in JSON representation - [@rcongiu](https://github.com/rcongiu).
+
+### 1.0 (2011/07/12)
+
+* Initial public release - [@rcongiu](https://github.com/rcongiu).
+

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ JsonSerde - a read/write SerDe for JSON Data
 
 [![Build Status](https://travis-ci.org/rcongiu/Hive-JSON-Serde.svg?branch=master)](https://travis-ci.org/rcongiu/Hive-JSON-Serde)
 
-AUTHOR: Roberto Congiu <rcongiu@yahoo.com>
-
 Serialization/Deserialization module for Apache Hadoop Hive
 JSON conversion UDF
 
@@ -326,39 +324,18 @@ to convert timestamps.
 
 I am using gitflow for the release cycle.
 
+### History
+
+This library is written by [Roberto Congiu](http://www.congiu.com) <rcongiu@yahoo.com>
+during his time at [OpenX Technologies, Inc.](https://www.openx.com).
+
+See [CHANGELOG](CHANGELOG.md) for details.
 
 ### THANKS
 
 Thanks to Douglas Crockford for the liberal license for his JSON library, and thanks to
 my employer OpenX and my boss Michael Lum for letting me open source the code.
 
-
-
-Versions:
-* 1.0: initial release
-* 1.1: fixed some string issues
-* 1.1.1 (2012/07/03): fixed Map Adapter (get and put would call themselves...ooops)
-* 1.1.2 (2012/07/26): Fixed issue with columns that are not mapped into JSON, reported by Michael Phung
-* 1.1.4 (2012/10/04): Fixed issue #13, problem with floats, Reported by Chuck Connell
-* 1.1.6 (2013/07/10): Fixed issue #28, error after 'alter table add columns'
-* 1.1.7 (2013/09/30): Fixed issue #25, timestamp support, fix parametrized build,
-		    Fixed issue #31 (static member shouldn't be static)
-* 1.1.8 (2014/01/22): Rewritten handling of numbers, so their parsing from string is delayed to
-                      deserialization time. Fixes #39, #45, #34, #29, #26, #22, #13
-* 1.1.9.1 (2014/02/02) fixed some bugs
-* 1.1.9.2 (2014/02/25)	fixed issue with { field = null }  #50,
-		      	support for array records,
-		      	fixed handling of null in arrays #54,
-		      	refactored Timestamp Handling
-* 1.2     (2014/06)     Refactored to multimodule for CDH5 compatibility
-* 1.3     (2014/09/08)  fixed #80, #82, #84, #85
-* 1.3.5   (2015/08/30)   Added UNIONTYPE support (#53), made CDH5 default, handle
-          empty array where an empty object should be (#112)
-* 1.3.6   (2015/10/08)   Added support for string boolean (#118) Updated docs (#116)
-			 Added support for HDP 2.3.
-* 1.3.7   (2015/12/10)   Added support for DATE type (hive 1.2.0 and higher)
-          (2016/01/30)   Added JSON UDF
-* 1.3.8   (???)		 Added support for mapping json keys with dots (#131)
 
 
 


### PR DESCRIPTION
On top of #180.

Trying to figure out what changed since the last release and found CHANGELOG lacking. This extracts CHANGELOG, defines a better format where you have the PR linked so it can be clicked, and gives credit to the people making PRs that are merged. I went through the git log/history and PR history and added quite a few items that were omitted. 

I moved the author's name into HISTORY, hope it's ok.

In the future you could require people submitting PRs to update the CHANGELOG. I use [danger-changelog](https://github.com/dblock/danger-changelog) for that if you're interested.