### PR TITLE
Update readme file (fixing variable name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,15 +305,15 @@ CREATE EXTERNAL TABLE tableWithNull
     'structMissingCol' STRUCT<name : STRING>
 )
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
-WITH SERDEPROPERTIES ("explicit.null.value" = "true");
+WITH SERDEPROPERTIES ("explicit.null" = "true");
 
 -- JSON string: {\"stringCol\":"blabla",\"stringNullCol\":null,\"structCol\":{\"name\":\"myName\"},\"structNullCol\":{\"name\":null}}
 LOAD DATA LOCAL INPATH 'pathToJsonFile.json' OVERWRITE INTO TABLE tableWithNull;
 
--- The output when ("explicit.null.value" = "true"):
+-- The output when ("explicit.null" = "true"):
 -- {\"stringCol\":"blabla",\"stringNullCol\":null,\"stringMissingCol\":null,\"structCol\":{\"name\":\"myName\"},\"structNullCol\":{\"name\":null},\"structMissingCol\":null}
 
--- The default output or when ("explicit.null.value" = "false"):
+-- The default output or when ("explicit.null" = "false"):
 -- {\"stringCol\":"blabla",\"structCol\":{\"name\":\"myName\"},\"structNullCol\":{}}
 ```
 

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
@@ -661,7 +661,7 @@ public class JsonSerDeTest {
         tbl.setProperty(serdeConstants.LIST_COLUMNS, "stringCol,nullCol,missingCol");
         tbl.setProperty(serdeConstants.LIST_COLUMN_TYPES, "string,string,string");
 
-        // Set 'explicit.null.value' to true
+        // Set 'explicit.null' to true
         tbl.setProperty(JsonSerDe.PROP_EXPLICIT_NULL, "true");
 
         serde.initialize(conf, tbl);
@@ -688,7 +688,7 @@ public class JsonSerDeTest {
         tbl.setProperty(serdeConstants.LIST_COLUMNS, "structCol,structNullCol,missingStructCol");
         tbl.setProperty(serdeConstants.LIST_COLUMN_TYPES, "struct<name:string>,struct<name:string>,struct<name:string>");
 
-        // Set 'explicit.null.value' to true
+        // Set 'explicit.null' to true
         tbl.setProperty(JsonSerDe.PROP_EXPLICIT_NULL, "true");
 
         serde.initialize(conf, tbl);


### PR DESCRIPTION
The configuration variable name (explicit.null.value) doesn't match the actual configuration variable name (explicit.null).

This PR is only for fixing the readme file (and 2 other comments in the code)