### PR TITLE
Fixed two tests in JsonSerDeTest

### DIFF
--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
@@ -676,7 +676,10 @@ public class JsonSerDeTest {
         assertTrue(soi.getStructFieldData(res, soi.getStructFieldRef("stringCol")).equals("str"));
         assertNull(soi.getStructFieldData(res, soi.getStructFieldRef("nullCol")));
         assertNull(soi.getStructFieldData(res, soi.getStructFieldRef("missingCol")));
-        assertEquals(jsonStr,"{\"nullCol\":null,\"stringCol\":\"str\",\"missingCol\":null}");
+
+        assertTrue(jsonStr.contains("\"nullCol\":null"));
+        assertTrue(jsonStr.contains("\"stringCol\":\"str\""));
+        assertTrue(jsonStr.contains("\"missingCol\":null"));
     }
 
     @Test
@@ -708,6 +711,9 @@ public class JsonSerDeTest {
 
         assertNull(soi.getStructFieldData(res, soi.getStructFieldRef("missingStructCol")));
 
-        assertEquals(jsonStr,"{\"missingStructCol\":null,\"structCol\":{\"name\":\"myName\"},\"structNullCol\":{\"name\":null}}");
+        assertTrue(jsonStr.contains("\"missingStructCol\":null"));
+        assertTrue(jsonStr.contains("\"structCol\":{\"name\":\"myName\"}"));
+        assertTrue(jsonStr.contains("\"structNullCol\":{\"name\":null}"));
+
     }
 }


### PR DESCRIPTION
**What is the purpose of the change:**
To address the validation issue created due to the potential variations in String ordering during comparison.

This PR aims to fix two tests:
```
org.openx.data.jsonserde.JsonSerDeTest.testNestedExplicitNullValue
org.openx.data.jsonserde.JsonSerDeTest.testExplicitNullValue
```

**REASON AND FIX:**

The issue arises while serializing the {column: column types} pair, the `result` returned is not in a constant order. This is because `result` is a JSONObject which internally uses HashMap and doesn’t maintain order.

https://github.com/rcongiu/Hive-JSON-Serde/blob/7a05e91bf80a781da30cc69e2f5698b78f5b3397/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java#L265

Due to this, validating the jsonStr with another string doesn’t turn out to return true.
The fix is to modify the assert statements in a way to check only the presence of the individual key-value pair and ignore the order.

**REPRODUCE:**
This was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. 

```
cd Hive-JSON-Serde
mvn install -pl json-serde -am -DskipTests
mvn -pl json-serde edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.openx.data.jsonserde.JsonSerDeTest#testNestedExplicitNullValue
```